### PR TITLE
Do not lower propertyname on writing to BIN to maintain state

### DIFF
--- a/foxbin2prg.prg
+++ b/foxbin2prg.prg
@@ -10528,7 +10528,7 @@ Define Class c_conversor_prg_a_bin As c_conversor_base
 
 		If Upper(Left(tcLine, 7)) == 'HIDDEN '
 			llBloqueEncontrado	= .T.
-			toClase._HiddenProps		= Lower( Alltrim( Substr( tcLine, 8 ) ) )
+			toClase._HiddenProps		= Alltrim( Substr( tcLine, 8 ) )
 		Endif
 
 		Release toClase, tcLine


### PR DESCRIPTION
Do not change the property name, VFP doesn't care and it introduces Changes not caused by the developer